### PR TITLE
Code cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^8.5 || ^9.0 || ^10.0 || ^11.0",
-		"squizlabs/php_codesniffer": "^3.5.0"
+		"squizlabs/php_codesniffer": "^3.5.0",
+		"laminas/laminas-coding-standard": "^3.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 use Doctrine\ORM;
 use Doctrine\Migrations\Tools\Console\Command as DoctrineCommand;
-use Interop\Container\ContainerInterface;
 use Skar\LaminasDoctrineORM\Service;
 use Skar\LaminasDoctrineORM\Command;
+use Psr\Container\ContainerInterface;
 use Skar\Cache;
 
 return [

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,77 +1,73 @@
 <?php
+
 declare(strict_types=1);
 
-use Doctrine\ORM;
 use Doctrine\Migrations\Tools\Console\Command as DoctrineCommand;
-use Skar\LaminasDoctrineORM\Service;
-use Skar\LaminasDoctrineORM\Command;
+use Doctrine\ORM;
 use Psr\Container\ContainerInterface;
 use Skar\Cache;
+use Skar\LaminasDoctrineORM\Command;
+use Skar\LaminasDoctrineORM\Service;
 
 return [
-	'dependencies' => [
-		'factories' => [
-			'doctrine.cache.array' => function(ContainerInterface $container) {
-				return new Cache\Cache(new Cache\Storage\Adapter\Memory());
-			},
-
-			ORM\EntityManager::class => Service\EntityManagerFactory::class,
-
-			DoctrineCommand\DiffCommand::class       => Command\MigrationsCommandFactory::class,
-			DoctrineCommand\DumpSchemaCommand::class => Command\MigrationsCommandFactory::class,
-			DoctrineCommand\ExecuteCommand::class    => Command\MigrationsCommandFactory::class,
-			DoctrineCommand\GenerateCommand::class   => Command\MigrationsCommandFactory::class,
-			DoctrineCommand\LatestCommand::class     => Command\MigrationsCommandFactory::class,
-			DoctrineCommand\MigrateCommand::class    => Command\MigrationsCommandFactory::class,
-			DoctrineCommand\RollupCommand::class     => Command\MigrationsCommandFactory::class,
-			DoctrineCommand\StatusCommand::class     => Command\MigrationsCommandFactory::class,
-			DoctrineCommand\UpToDateCommand::class   => Command\MigrationsCommandFactory::class,
-			DoctrineCommand\VersionCommand::class    => Command\MigrationsCommandFactory::class,
-		],
-		'abstract_factories' => [
-			Service\ServiceAbstractFactory::class,
-		],
-	],
-
-	'laminas-cli' => [
-		'commands' => [
-			'doctrine:migrations:diff'        => DoctrineCommand\DiffCommand::class,
-			'doctrine:migrations:dump-schema' => DoctrineCommand\DumpSchemaCommand::class,
-			'doctrine:migrations:execute'     => DoctrineCommand\ExecuteCommand::class,
-			'doctrine:migrations:generate'    => DoctrineCommand\GenerateCommand::class,
-			'doctrine:migrations:latest'      => DoctrineCommand\LatestCommand::class,
-			'doctrine:migrations:migrate'     => DoctrineCommand\MigrateCommand::class,
-			'doctrine:migrations:rollup'      => DoctrineCommand\RollupCommand::class,
-			'doctrine:migrations:status'      => DoctrineCommand\StatusCommand::class,
-			'doctrine:migrations:up-to-date'  => DoctrineCommand\UpToDateCommand::class,
-			'doctrine:migrations:version'     => DoctrineCommand\VersionCommand::class,
-		],
-	],
-
-	'doctrine_factories' => [
-		'entity_manager' => Service\EntityManagerFactory::class,
-		'connection'     => Service\ConnectionFactory::class,
-		'configuration'  => Service\ConfigurationFactory::class,
-		'driver'         => Service\DriverFactory::class,
-		'event_manager'  => Service\EventManagerFactory::class,
-	],
-
-	'doctrine' => [
-		'migrations' => [
-			'orm_default' => [
-				'table_storage' => [
-					'table_name'                 => 'migrations_executed',
-					'version_column_name'        => 'version',
-					'version_column_length'      => 255,
-					'executed_at_column_name'    => 'executed_at',
-					'execution_time_column_name' => 'execution_time',
-				],
-				'migrations_paths' => [
-					'Skar\LaminasDoctrineORM' => 'data/migrations',
-				],
-				'all_or_nothing'          => true,
-				'check_database_platform' => true,
-			],
-		],
-	],
+    'dependencies'       => [
+        'factories'          => [
+            'doctrine.cache.array'                   => function (ContainerInterface $container) {
+                return new Cache\Cache(new Cache\Storage\Adapter\Memory());
+            },
+            ORM\EntityManager::class                 => Service\EntityManagerFactory::class,
+            DoctrineCommand\DiffCommand::class       => Command\MigrationsCommandFactory::class,
+            DoctrineCommand\DumpSchemaCommand::class => Command\MigrationsCommandFactory::class,
+            DoctrineCommand\ExecuteCommand::class    => Command\MigrationsCommandFactory::class,
+            DoctrineCommand\GenerateCommand::class   => Command\MigrationsCommandFactory::class,
+            DoctrineCommand\LatestCommand::class     => Command\MigrationsCommandFactory::class,
+            DoctrineCommand\MigrateCommand::class    => Command\MigrationsCommandFactory::class,
+            DoctrineCommand\RollupCommand::class     => Command\MigrationsCommandFactory::class,
+            DoctrineCommand\StatusCommand::class     => Command\MigrationsCommandFactory::class,
+            DoctrineCommand\UpToDateCommand::class   => Command\MigrationsCommandFactory::class,
+            DoctrineCommand\VersionCommand::class    => Command\MigrationsCommandFactory::class,
+        ],
+        'abstract_factories' => [
+            Service\ServiceAbstractFactory::class,
+        ],
+    ],
+    'laminas-cli'        => [
+        'commands' => [
+            'doctrine:migrations:diff'        => DoctrineCommand\DiffCommand::class,
+            'doctrine:migrations:dump-schema' => DoctrineCommand\DumpSchemaCommand::class,
+            'doctrine:migrations:execute'     => DoctrineCommand\ExecuteCommand::class,
+            'doctrine:migrations:generate'    => DoctrineCommand\GenerateCommand::class,
+            'doctrine:migrations:latest'      => DoctrineCommand\LatestCommand::class,
+            'doctrine:migrations:migrate'     => DoctrineCommand\MigrateCommand::class,
+            'doctrine:migrations:rollup'      => DoctrineCommand\RollupCommand::class,
+            'doctrine:migrations:status'      => DoctrineCommand\StatusCommand::class,
+            'doctrine:migrations:up-to-date'  => DoctrineCommand\UpToDateCommand::class,
+            'doctrine:migrations:version'     => DoctrineCommand\VersionCommand::class,
+        ],
+    ],
+    'doctrine_factories' => [
+        'entity_manager' => Service\EntityManagerFactory::class,
+        'connection'     => Service\ConnectionFactory::class,
+        'configuration'  => Service\ConfigurationFactory::class,
+        'driver'         => Service\DriverFactory::class,
+        'event_manager'  => Service\EventManagerFactory::class,
+    ],
+    'doctrine'           => [
+        'migrations' => [
+            'orm_default' => [
+                'table_storage'           => [
+                    'table_name'                 => 'migrations_executed',
+                    'version_column_name'        => 'version',
+                    'version_column_length'      => 255,
+                    'executed_at_column_name'    => 'executed_at',
+                    'execution_time_column_name' => 'execution_time',
+                ],
+                'migrations_paths'        => [
+                    'Skar\LaminasDoctrineORM' => 'data/migrations',
+                ],
+                'all_or_nothing'          => true,
+                'check_database_platform' => true,
+            ],
+        ],
+    ],
 ];

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,44 +13,7 @@
 	<!-- Paths to check -->
 	<file>config</file>
 	<file>src</file>
-	<file>test</file>
 
-	<!-- inherit rules from PSR-2 -->
-	<rule ref="PSR2">
-		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction"/>
-		<exclude name="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine"/>
-		<exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/>
-		<!-- Allow Tabs -->
-		<exclude name="Generic.WhiteSpace.DisallowTabIndent"/>
-	</rule>
-
-	<rule ref="Generic.WhiteSpace.ScopeIndent">
-		<properties>
-			<property name="ignoreIndentationTokens" type="array" value="T_COMMENT,T_DOC_COMMENT_OPEN_TAG"/>
-			<property name="tabIndent" type="bool" value="true"/>
-		</properties>
-	</rule>
-
-	<arg name="tab-width" value="4"/>
-	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
-
-	<rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
-
-	<rule ref="Squiz.WhiteSpace.OperatorSpacing">
-		<properties>
-			<property name="ignoreNewlines" value="true"/>
-		</properties>
-	</rule>
-
-	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
-
-	<rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
-		<properties>
-			<property name="ignoreBlankLines" value="false"/>
-		</properties>
-	</rule>
-
-	<rule ref="PSR1.Files.SideEffects">
-		<exclude-pattern>public/index.php</exclude-pattern>
-	</rule>
+	<!-- Include all rules from the Laminas Coding Standard -->
+	<rule ref="LaminasCodingStandard"/>
 </ruleset>

--- a/src/Command/MigrationsCommandFactory.php
+++ b/src/Command/MigrationsCommandFactory.php
@@ -8,9 +8,9 @@ use Doctrine\Migrations\Configuration\Migration\ConfigurationArray;
 use Doctrine\Migrations\Configuration\EntityManager\ExistingEntityManager;
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Tools\Console\Command\DoctrineCommand;
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container;
+use Psr\Container\ContainerInterface;
 
 class MigrationsCommandFactory implements FactoryInterface {
 	/**

--- a/src/Command/MigrationsCommandFactory.php
+++ b/src/Command/MigrationsCommandFactory.php
@@ -1,42 +1,43 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Skar\LaminasDoctrineORM\Command;
 
-use Doctrine\ORM\EntityManager;
-use Doctrine\Migrations\Configuration\Migration\ConfigurationArray;
 use Doctrine\Migrations\Configuration\EntityManager\ExistingEntityManager;
+use Doctrine\Migrations\Configuration\Migration\ConfigurationArray;
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Tools\Console\Command\DoctrineCommand;
+use Doctrine\ORM\EntityManager;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container;
 use Psr\Container\ContainerInterface;
 
-class MigrationsCommandFactory implements FactoryInterface {
-	/**
-	 * @inheritDoc
-	 *
-	 * @param ContainerInterface $container
-	 * @param $requestedName
-	 * @param array|null $options
-	 *
-	 * @return DoctrineCommand
-	 *
-	 * @throws Container\ContainerExceptionInterface
-	 * @throws Container\NotFoundExceptionInterface
-	 */
-	public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): DoctrineCommand {
-		/** @var array $config */
-		$config = $container->get('config')['doctrine']['migrations']['orm_default'];
+class MigrationsCommandFactory implements FactoryInterface
+{
+    /**
+     * @inheritDoc
+     * @param array $options
+     * @return DoctrineCommand
+     * @throws Container\ContainerExceptionInterface
+     * @throws Container\NotFoundExceptionInterface
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null
+    ): DoctrineCommand {
+        /** @var array $config */
+        $config = $container->get('config')['doctrine']['migrations']['orm_default'];
 
-		/** @var EntityManager $entityManager */
-		$entityManager = $container->get(EntityManager::class);
+        /** @var EntityManager $entityManager */
+        $entityManager = $container->get(EntityManager::class);
 
-		return new $requestedName(
-			DependencyFactory::fromEntityManager(
-				new ConfigurationArray($config),
-				new ExistingEntityManager($entityManager)
-			)
-		);
-	}
+        return new $requestedName(
+            DependencyFactory::fromEntityManager(
+                new ConfigurationArray($config),
+                new ExistingEntityManager($entityManager)
+            )
+        );
+    }
 }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -1,15 +1,18 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Skar\LaminasDoctrineORM;
 
-class ConfigProvider {
-	/**
-	 * Retrieve configuration for laminas-diactoros.
-	 *
-	 * @return mixed[]
-	 */
-	public function __invoke() : array {
-		return require __DIR__ . '/../config/module.config.php';
-	}
+class ConfigProvider
+{
+    /**
+     * Retrieve configuration for laminas-diactoros.
+     *
+     * @return mixed[]
+     */
+    public function __invoke(): array
+    {
+        return require __DIR__ . '/../config/module.config.php';
+    }
 }

--- a/src/Service/AbstractFactory.php
+++ b/src/Service/AbstractFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Skar\LaminasDoctrineORM\Service;
@@ -6,38 +7,31 @@ namespace Skar\LaminasDoctrineORM\Service;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\Stdlib\ArrayUtils;
 
-abstract class AbstractFactory implements FactoryInterface {
-	protected array $config;
+use function sprintf;
 
-	/**
-	 * AbstractFactory constructor.
-	 *
-	 * @param array $config
-	 */
-	public function __construct(array $config = []) {
-		$this->config = ArrayUtils::merge($this->getDefaultConfig(), $config);
-	}
+abstract class AbstractFactory implements FactoryInterface
+{
+    protected array $config;
 
-	/**
-	 * Returns service full name
-	 *
-	 * @param string $type
-	 * @param string|null $key
-	 *
-	 * @return string
-	 */
-	protected function getServiceName(string $type, ?string $key = null): string {
-		return sprintf(
-			'doctrine.%s.%s',
-			$type,
-			($key === null) ? $this->config[$type] : $key
-		);
-	}
+    public function __construct(array $config = [])
+    {
+        $this->config = ArrayUtils::merge($this->getDefaultConfig(), $config);
+    }
 
-	/**
-	 * Returns default config
-	 *
-	 * @return array
-	 */
-	abstract protected function getDefaultConfig(): array;
+    /**
+     * Returns service full name
+     */
+    protected function getServiceName(string $type, ?string $key = null): string
+    {
+        return sprintf(
+            'doctrine.%s.%s',
+            $type,
+            $key ?? $this->config[$type]
+        );
+    }
+
+    /**
+     * Returns default config
+     */
+    abstract protected function getDefaultConfig(): array;
 }

--- a/src/Service/ConfigurationFactory.php
+++ b/src/Service/ConfigurationFactory.php
@@ -11,13 +11,13 @@ use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Cache\RegionsConfiguration;
 use Doctrine\ORM\Exception\InvalidEntityRepository;
 use Doctrine\ORM\Mapping\EntityListenerResolver;
-use Interop\Container\ContainerInterface;
-use Psr\Container;
 use InvalidArgumentException;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 class ConfigurationFactory extends AbstractFactory {
 	/**
-	 * @param Container\ContainerInterface $container
 	 * @param string $requestedName
 	 * @param array|null $options
 	 *
@@ -25,10 +25,14 @@ class ConfigurationFactory extends AbstractFactory {
 	 *
 	 * @throws DBAL\Exception
 	 * @throws InvalidEntityRepository
-	 * @throws Container\ContainerExceptionInterface
-	 * @throws Container\NotFoundExceptionInterface
+     * @throws ContainerExceptionInterface
+     * @throws NotFoundExceptionInterface
 	 */
-	public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): Configuration {
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null
+    ): Configuration {
 		$configuration = new Configuration();
 
 		$configuration->setAutoGenerateProxyClasses($this->config['auto_generate_proxy_classes']);

--- a/src/Service/ConfigurationFactory.php
+++ b/src/Service/ConfigurationFactory.php
@@ -1,14 +1,15 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Skar\LaminasDoctrineORM\Service;
 
 use Doctrine\DBAL;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Cache\RegionsConfiguration;
+use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Exception\InvalidEntityRepository;
 use Doctrine\ORM\Mapping\EntityListenerResolver;
 use InvalidArgumentException;
@@ -16,213 +17,219 @@ use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
-class ConfigurationFactory extends AbstractFactory {
-	/**
-	 * @param string $requestedName
-	 * @param array|null $options
-	 *
-	 * @return Configuration
-	 *
-	 * @throws DBAL\Exception
-	 * @throws InvalidEntityRepository
+use function array_key_exists;
+use function is_string;
+use function sprintf;
+
+class ConfigurationFactory extends AbstractFactory
+{
+    /**
+     * @inheritDoc
+     * @throws DBAL\Exception
+     * @throws InvalidEntityRepository
      * @throws ContainerExceptionInterface
      * @throws NotFoundExceptionInterface
-	 */
+     */
     public function __invoke(
         ContainerInterface $container,
         string $requestedName,
         ?array $options = null
     ): Configuration {
-		$configuration = new Configuration();
+        $configuration = new Configuration();
 
-		$configuration->setAutoGenerateProxyClasses($this->config['auto_generate_proxy_classes']);
-		$configuration->setProxyDir($this->config['proxy_dir']);
-		$configuration->setProxyNamespace($this->config['proxy_namespace']);
+        $configuration->setAutoGenerateProxyClasses($this->config['auto_generate_proxy_classes']);
+        $configuration->setProxyDir($this->config['proxy_dir']);
+        $configuration->setProxyNamespace($this->config['proxy_namespace']);
 
-		$configuration->setEntityNamespaces($this->config['entity_namespaces']);
+        $configuration->setEntityNamespaces($this->config['entity_namespaces']);
 
-		$configuration->setCustomDatetimeFunctions($this->config['datetime_functions']);
-		$configuration->setCustomStringFunctions($this->config['string_functions']);
-		$configuration->setCustomNumericFunctions($this->config['numeric_functions']);
+        $configuration->setCustomDatetimeFunctions($this->config['datetime_functions']);
+        $configuration->setCustomStringFunctions($this->config['string_functions']);
+        $configuration->setCustomNumericFunctions($this->config['numeric_functions']);
 
-		if ($this->config['class_metadata_factory_name']) {
-			$configuration->setClassMetadataFactoryName($this->config['class_metadata_factory_name']);
-		}
+        if ($this->config['class_metadata_factory_name']) {
+            $configuration->setClassMetadataFactoryName($this->config['class_metadata_factory_name']);
+        }
 
-		foreach ($this->config['named_queries'] as $name => $query) {
-			$configuration->addNamedQuery($name, $query);
-		}
+        foreach ($this->config['named_queries'] as $name => $query) {
+            $configuration->addNamedQuery($name, $query);
+        }
 
-		foreach ($this->config['named_native_queries'] as $name => $query) {
-			$configuration->addNamedNativeQuery($name, $query['sql'], new $query['rsm']());
-		}
+        foreach ($this->config['named_native_queries'] as $name => $query) {
+            $configuration->addNamedNativeQuery($name, $query['sql'], new $query['rsm']());
+        }
 
-		foreach ($this->config['custom_hydration_modes'] as $name => $query) {
-			$configuration->addCustomHydrationMode($name, $query);
-		}
+        foreach ($this->config['custom_hydration_modes'] as $name => $query) {
+            $configuration->addCustomHydrationMode($name, $query);
+        }
 
-		foreach ($this->config['filters'] as $name => $class) {
-			$configuration->addFilter($name, $class);
-		}
+        foreach ($this->config['filters'] as $name => $class) {
+            $configuration->addFilter($name, $class);
+        }
 
-		$configuration->setMetadataCache($container->get(
-			$this->getServiceName('cache', $this->config['metadata_cache'])
-		));
-		$configuration->setQueryCache($container->get(
-			$this->getServiceName('cache', $this->config['query_cache'])
-		));
-		$configuration->setResultCache($container->get(
-			$this->getServiceName('cache', $this->config['result_cache'])
-		));
-		$configuration->setHydrationCache($container->get(
-			$this->getServiceName('cache', $this->config['hydration_cache'])
-		));
+        $configuration->setMetadataCache($container->get(
+            $this->getServiceName('cache', $this->config['metadata_cache'])
+        ));
+        $configuration->setQueryCache($container->get(
+            $this->getServiceName('cache', $this->config['query_cache'])
+        ));
+        $configuration->setResultCache($container->get(
+            $this->getServiceName('cache', $this->config['result_cache'])
+        ));
+        $configuration->setHydrationCache($container->get(
+            $this->getServiceName('cache', $this->config['hydration_cache'])
+        ));
 
-		$configuration->setMetadataDriverImpl($container->get($this->getServiceName('driver')));
+        $configuration->setMetadataDriverImpl($container->get($this->getServiceName('driver')));
 
-		if ($namingStrategy = $this->config['naming_strategy']) {
-			if (is_string($namingStrategy)) {
-				if (!$container->has($namingStrategy)) {
-					throw new InvalidArgumentException(sprintf('Naming strategy "%s" not found', $namingStrategy));
-				}
+        if ($namingStrategy = $this->config['naming_strategy']) {
+            if (is_string($namingStrategy)) {
+                if (! $container->has($namingStrategy)) {
+                    throw new InvalidArgumentException(sprintf('Naming strategy "%s" not found', $namingStrategy));
+                }
 
-				$configuration->setNamingStrategy($container->get($namingStrategy));
-			} else {
-				$configuration->setNamingStrategy($namingStrategy);
-			}
-		}
+                $configuration->setNamingStrategy($container->get($namingStrategy));
+            } else {
+                $configuration->setNamingStrategy($namingStrategy);
+            }
+        }
 
-		if ($quoteStrategy = $this->config['quote_strategy']) {
-			if (is_string($quoteStrategy)) {
-				if (!$container->has($quoteStrategy)) {
-					throw new InvalidArgumentException(sprintf('Quote strategy "%s" not found', $quoteStrategy));
-				}
+        if ($quoteStrategy = $this->config['quote_strategy']) {
+            if (is_string($quoteStrategy)) {
+                if (! $container->has($quoteStrategy)) {
+                    throw new InvalidArgumentException(sprintf('Quote strategy "%s" not found', $quoteStrategy));
+                }
 
-				$configuration->setQuoteStrategy($container->get($quoteStrategy));
-			} else {
-				$configuration->setQuoteStrategy($quoteStrategy);
-			}
-		}
+                $configuration->setQuoteStrategy($container->get($quoteStrategy));
+            } else {
+                $configuration->setQuoteStrategy($quoteStrategy);
+            }
+        }
 
-		if ($repositoryFactory = $this->config['repository_factory']) {
-			if (is_string($repositoryFactory)) {
-				if (!$container->has($repositoryFactory)) {
-					throw new InvalidArgumentException(sprintf('Repository factory "%s" not found', $repositoryFactory));
-				}
+        if ($repositoryFactory = $this->config['repository_factory']) {
+            if (is_string($repositoryFactory)) {
+                if (! $container->has($repositoryFactory)) {
+                    throw new InvalidArgumentException(
+                        sprintf('Repository factory "%s" not found', $repositoryFactory)
+                    );
+                }
 
-				$configuration->setRepositoryFactory($container->get($repositoryFactory));
-			} else {
-				$configuration->setRepositoryFactory($repositoryFactory);
-			}
-		}
+                $configuration->setRepositoryFactory($container->get($repositoryFactory));
+            } else {
+                $configuration->setRepositoryFactory($repositoryFactory);
+            }
+        }
 
-		if ($entityListenerResolver = $this->config['entity_listener_resolver']) {
-			if ($entityListenerResolver instanceof EntityListenerResolver) {
-				$configuration->setEntityListenerResolver($entityListenerResolver);
-			} else {
-				$configuration->setEntityListenerResolver($container->get($entityListenerResolver));
-			}
-		}
+        if ($entityListenerResolver = $this->config['entity_listener_resolver']) {
+            if ($entityListenerResolver instanceof EntityListenerResolver) {
+                $configuration->setEntityListenerResolver($entityListenerResolver);
+            } else {
+                $configuration->setEntityListenerResolver($container->get($entityListenerResolver));
+            }
+        }
 
-		if ($this->config['second_level_cache']['enabled']) {
-			$regionsConfig = new RegionsConfiguration(
-				$this->config['second_level_cache']['default_lifetime'],
-				$this->config['second_level_cache']['default_lock_lifetime']
-			);
+        if ($this->config['second_level_cache']['enabled']) {
+            $regionsConfig = new RegionsConfiguration(
+                $this->config['second_level_cache']['default_lifetime'],
+                $this->config['second_level_cache']['default_lock_lifetime']
+            );
 
-			foreach ($this->config['second_level_cache']['regions'] as $regionName => $regionConfig) {
-				if (array_key_exists('lifetime', $regionConfig)) {
-					$regionsConfig->setLifetime($regionName, $regionConfig['lifetime']);
-				}
+            foreach ($this->config['second_level_cache']['regions'] as $regionName => $regionConfig) {
+                if (array_key_exists('lifetime', $regionConfig)) {
+                    $regionsConfig->setLifetime($regionName, $regionConfig['lifetime']);
+                }
 
-				if (array_key_exists('lock_lifetime', $regionConfig)) {
-					$regionsConfig->setLockLifetime($regionName, $regionConfig['lock_lifetime']);
-				}
-			}
+                if (array_key_exists('lock_lifetime', $regionConfig)) {
+                    $regionsConfig->setLockLifetime($regionName, $regionConfig['lock_lifetime']);
+                }
+            }
 
-			$cacheFactory = new DefaultCacheFactory($regionsConfig, $configuration->getResultCache());
-			$cacheFactory->setFileLockRegionDirectory($this->config['second_level_cache']['file_lock_region_directory']);
+            $cacheFactory = new DefaultCacheFactory($regionsConfig, $configuration->getResultCache());
+            $cacheFactory->setFileLockRegionDirectory(
+                $this->config['second_level_cache']['file_lock_region_directory']
+            );
 
-			$cacheConfiguration = new CacheConfiguration();
-			$cacheConfiguration->setCacheFactory($cacheFactory);
-			$cacheConfiguration->setRegionsConfiguration($regionsConfig);
+            $cacheConfiguration = new CacheConfiguration();
+            $cacheConfiguration->setCacheFactory($cacheFactory);
+            $cacheConfiguration->setRegionsConfiguration($regionsConfig);
 
-			$configuration->setSecondLevelCacheEnabled(true);
-			$configuration->setSecondLevelCacheConfiguration($cacheConfiguration);
-		}
+            $configuration->setSecondLevelCacheEnabled(true);
+            $configuration->setSecondLevelCacheConfiguration($cacheConfiguration);
+        }
 
-		if ($schemaAssetsFilter = $this->config['schema_assets_filter']) {
-			$configuration->setSchemaAssetsFilter($schemaAssetsFilter);
-		}
+        if ($schemaAssetsFilter = $this->config['schema_assets_filter']) {
+            $configuration->setSchemaAssetsFilter($schemaAssetsFilter);
+        }
 
-		if ($className = $this->config['default_repository_class_name']) {
-			$configuration->setDefaultRepositoryClassName($className);
-		}
+        if ($className = $this->config['default_repository_class_name']) {
+            $configuration->setDefaultRepositoryClassName($className);
+        }
 
-		if ($this->config['sql_logger']) {
-			$configuration->setSQLLogger($container->get(
-				$this->getServiceName($this->config['sql_logger'])
-			));
-		}
+        if ($this->config['sql_logger']) {
+            $configuration->setSQLLogger($container->get(
+                $this->getServiceName($this->config['sql_logger'])
+            ));
+        }
 
-		foreach ($this->config['types'] as $name => $class) {
-			if (Type::hasType($name)) {
-				Type::overrideType($name, $class);
-			} else {
-				Type::addType($name, $class);
-			}
-		}
+        foreach ($this->config['types'] as $name => $class) {
+            if (Type::hasType($name)) {
+                Type::overrideType($name, $class);
+            } else {
+                Type::addType($name, $class);
+            }
+        }
 
-		if ($this->config['middlewares'] !== []) {
-			$middlewares = [];
-			foreach ($this->config['middlewares'] as $middleware) {
-				$middlewares[] = $container->get($middleware);
-			}
+        if ($this->config['middlewares'] !== []) {
+            $middlewares = [];
+            foreach ($this->config['middlewares'] as $middleware) {
+                $middlewares[] = $container->get($middleware);
+            }
 
-			$configuration->setMiddlewares($middlewares);
-		}
+            $configuration->setMiddlewares($middlewares);
+        }
 
-		return $configuration;
-	}
+        return $configuration;
+    }
 
-	/**
-	 * @inheritDoc
-	 */
-	protected function getDefaultConfig(): array {
-		return [
-			'metadata_cache'                  => 'array',
-			'query_cache'                     => 'array',
-			'result_cache'                    => 'array',
-			'hydration_cache'                 => 'array',
-			'driver'                          => 'orm_default',
-			'auto_generate_proxy_classes'     => true,
-			'proxy_dir'                       => 'data/cache/DoctrineORM/Proxy',
-			'proxy_namespace'                 => 'DoctrineORM\Proxy',
-			'entity_namespaces'               => [],
-			'datetime_functions'              => [],
-			'string_functions'                => [],
-			'numeric_functions'               => [],
-			'filters'                         => [],
-			'named_queries'                   => [],
-			'named_native_queries'            => [],
-			'custom_hydration_modes'          => [],
-			'types'                           => [],
-			'naming_strategy'                 => null,
-			'quote_strategy'                  => null,
-			'default_repository_class_name'   => null,
-			'repository_factory'              => null,
-			'class_metadata_factory_name'     => null,
-			'entity_listener_resolver'        => null,
-			'sql_logger'                      => null,
-			'schema_assets_filter'            => null,
-			'middlewares'                     => [],
-			'second_level_cache'              => [
-				'enabled'                    => false,
-				'default_lifetime'           => 3600,
-				'default_lock_lifetime'      => 60,
-				'file_lock_region_directory' => 'data/cache/DoctrineORM',
-				'regions'                    => [],
-			],
-		];
-	}
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultConfig(): array
+    {
+        return [
+            'metadata_cache'                => 'array',
+            'query_cache'                   => 'array',
+            'result_cache'                  => 'array',
+            'hydration_cache'               => 'array',
+            'driver'                        => 'orm_default',
+            'auto_generate_proxy_classes'   => true,
+            'proxy_dir'                     => 'data/cache/DoctrineORM/Proxy',
+            'proxy_namespace'               => 'DoctrineORM\Proxy',
+            'entity_namespaces'             => [],
+            'datetime_functions'            => [],
+            'string_functions'              => [],
+            'numeric_functions'             => [],
+            'filters'                       => [],
+            'named_queries'                 => [],
+            'named_native_queries'          => [],
+            'custom_hydration_modes'        => [],
+            'types'                         => [],
+            'naming_strategy'               => null,
+            'quote_strategy'                => null,
+            'default_repository_class_name' => null,
+            'repository_factory'            => null,
+            'class_metadata_factory_name'   => null,
+            'entity_listener_resolver'      => null,
+            'sql_logger'                    => null,
+            'schema_assets_filter'          => null,
+            'middlewares'                   => [],
+            'second_level_cache'            => [
+                'enabled'                    => false,
+                'default_lifetime'           => 3600,
+                'default_lock_lifetime'      => 60,
+                'file_lock_region_directory' => 'data/cache/DoctrineORM',
+                'regions'                    => [],
+            ],
+        ];
+    }
 }

--- a/src/Service/ConnectionFactory.php
+++ b/src/Service/ConnectionFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Skar\LaminasDoctrineORM\Service;
@@ -6,52 +7,61 @@ namespace Skar\LaminasDoctrineORM\Service;
 use Doctrine\DBAL;
 use Psr\Container\ContainerInterface;
 
-class ConnectionFactory extends AbstractFactory {
-	/**
-	 * @inheritDoc
-	 *
-	 * @return DBAL\Connection
-	 *
-	 * @throws DBAL\Exception
-	 */
-	public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): DBAL\Connection {
-		$params = [
-			'driverClass'  => $this->config['driver_class'],
-			'wrapperClass' => $this->config['wrapper_class'],
-			'pdo'          => is_string($this->config['pdo']) ? $container->get($this->config['pdo']) : $this->config['pdo'],
-		];
+use function array_merge;
+use function is_string;
 
-		$connection = DBAL\DriverManager::getConnection(
-			array_merge($params, $this->config['params']),
-			$container->get($this->getServiceName('configuration')),
-			$container->get($this->getServiceName('event_manager'))
-		);
+class ConnectionFactory extends AbstractFactory
+{
+    /**
+     * @inheritDoc
+     * @return DBAL\Connection
+     * @throws DBAL\Exception
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null
+    ): DBAL\Connection {
+        $params = [
+            'driverClass'  => $this->config['driver_class'],
+            'wrapperClass' => $this->config['wrapper_class'],
+            'pdo'          => is_string($this->config['pdo'])
+                ? $container->get($this->config['pdo'])
+                : $this->config['pdo'],
+        ];
 
-		$platform = $connection->getDatabasePlatform();
-		foreach ($this->config['doctrine_type_mappings'] as $dbType => $doctrineType) {
-			$platform->registerDoctrineTypeMapping($dbType, $doctrineType);
-		}
-		foreach ($this->config['doctrine_commented_types'] as $doctrineType) {
-			$platform->markDoctrineTypeCommented($doctrineType);
-		}
+        $connection = DBAL\DriverManager::getConnection(
+            array_merge($params, $this->config['params']),
+            $container->get($this->getServiceName('configuration')),
+            $container->get($this->getServiceName('event_manager'))
+        );
 
-		return $connection;
-	}
+        $platform = $connection->getDatabasePlatform();
+        foreach ($this->config['doctrine_type_mappings'] as $dbType => $doctrineType) {
+            $platform->registerDoctrineTypeMapping($dbType, $doctrineType);
+        }
+        foreach ($this->config['doctrine_commented_types'] as $doctrineType) {
+            $platform->markDoctrineTypeCommented($doctrineType);
+        }
 
-	/**
-	 * @inheritDoc
-	 */
-	protected function getDefaultConfig(): array {
-		return [
-			'configuration'            => 'orm_default',
-			'event_manager'            => 'orm_default',
-			'pdo'                      => null,
-			'driver_class'             => null,
-			'wrapper_class'            => null,
-			'params'                   => [],
-			'doctrine_type_mappings'   => [],
-			'doctrine_commented_types' => [],
-			'use_save_points'          => false,
-		];
-	}
+        return $connection;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultConfig(): array
+    {
+        return [
+            'configuration'            => 'orm_default',
+            'event_manager'            => 'orm_default',
+            'pdo'                      => null,
+            'driver_class'             => null,
+            'wrapper_class'            => null,
+            'params'                   => [],
+            'doctrine_type_mappings'   => [],
+            'doctrine_commented_types' => [],
+            'use_save_points'          => false,
+        ];
+    }
 }

--- a/src/Service/ConnectionFactory.php
+++ b/src/Service/ConnectionFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Skar\LaminasDoctrineORM\Service;
 
 use Doctrine\DBAL;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 class ConnectionFactory extends AbstractFactory {
 	/**

--- a/src/Service/DriverFactory.php
+++ b/src/Service/DriverFactory.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Skar\LaminasDoctrineORM\Service;
 
-use Interop\Container\ContainerInterface;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\Driver\FileDriver;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
@@ -15,6 +14,7 @@ use Doctrine\Common\Annotations\IndexedReader;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Laminas\Stdlib\ArrayUtils;
 use \InvalidArgumentException;
+use Psr\Container\ContainerInterface;
 
 class DriverFactory extends AbstractFactory {
 	/**

--- a/src/Service/DriverFactory.php
+++ b/src/Service/DriverFactory.php
@@ -1,96 +1,102 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Skar\LaminasDoctrineORM\Service;
 
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\IndexedReader;
+use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\ORM\Mapping\Driver\AttributeDriver;
-use Doctrine\Persistence\Mapping\Driver\FileDriver;
-use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
-use Doctrine\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Persistence\Mapping\Driver\AnnotationDriver;
 use Doctrine\Persistence\Mapping\Driver\DefaultFileLocator;
-use Doctrine\Common\Annotations\PsrCachedReader;
-use Doctrine\Common\Annotations\IndexedReader;
-use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Persistence\Mapping\Driver\FileDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
+use InvalidArgumentException;
 use Laminas\Stdlib\ArrayUtils;
-use \InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 
-class DriverFactory extends AbstractFactory {
-	/**
-	 * @inheritDoc
-	 *
-	 * @return MappingDriver
-	 */
-	public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): MappingDriver {
-		return $this->createDriver($this->config, $container);
-	}
+use function class_exists;
+use function is_subclass_of;
+use function sprintf;
 
-	/**
-	 * @param array $config
-	 * @param ContainerInterface $container
-	 *
-	 * @return MappingDriver
-	 */
-	protected function createDriver(array $config, ContainerInterface $container) {
-		if (!$class = $config['class']) {
-			throw new InvalidArgumentException('Drivers must specify a class');
-		}
+class DriverFactory extends AbstractFactory
+{
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null
+    ): MappingDriver {
+        return $this->createDriver($this->config, $container);
+    }
 
-		if (!class_exists($class)) {
-			throw new InvalidArgumentException(sprintf('Driver with type "%s" could not be found', $class));
-		}
+    protected function createDriver(
+        array $config,
+        ContainerInterface $container
+    ): MappingDriverChain|FileDriver|AttributeDriver|MappingDriver {
+        if (! $class = $config['class']) {
+            throw new InvalidArgumentException('Drivers must specify a class');
+        }
 
-		if ($class === AttributeDriver::class || is_subclass_of($class, AttributeDriver::class)) {
-			// AttributeDriver extends AnnotationDriver in violation of the Liskov substitution principle
-			$driver = new $class($config['paths']);
-		} elseif ($class === AnnotationDriver::class || is_subclass_of($class, AnnotationDriver::class)) {
-			// Special options for AnnotationDrivers.
-			$reader = new PsrCachedReader(
-				new IndexedReader(new AnnotationReader()),
-				$container->get($this->getServiceName('cache'))
-			);
-			$driver = new $class($reader, $config['paths']);
-		} else {
-			$driver = new $class($config['paths']);
-		}
+        if (! class_exists($class)) {
+            throw new InvalidArgumentException(sprintf('Driver with type "%s" could not be found', $class));
+        }
 
-		if ($config['extension'] && $driver instanceof FileDriver) {
-			$locator = $driver->getLocator();
+        if ($class === AttributeDriver::class || is_subclass_of($class, AttributeDriver::class)) {
+            // AttributeDriver extends AnnotationDriver in violation of the Liskov substitution principle
+            $driver = new $class($config['paths']);
+        } elseif ($class === AnnotationDriver::class || is_subclass_of($class, AnnotationDriver::class)) {
+            // Special options for AnnotationDrivers.
+            $reader = new PsrCachedReader(
+                new IndexedReader(new AnnotationReader()),
+                $container->get($this->getServiceName('cache'))
+            );
+            $driver = new $class($reader, $config['paths']);
+        } else {
+            $driver = new $class($config['paths']);
+        }
 
-			if (get_class($locator) !== DefaultFileLocator::class) {
-				throw new InvalidArgumentException(sprintf(
-					'Discovered file locator for driver of type "%s" is an instance of "%s". This factory '
-					. 'supports only the DefaultFileLocator when an extension is set for the file locator',
-					get_class($driver),
-					get_class($locator)
-				));
-			}
+        if ($config['extension'] && $driver instanceof FileDriver) {
+            $locator = $driver->getLocator();
 
-			$driver->setLocator(new DefaultFileLocator($locator->getPaths(), $config['extension']));
-		}
+            if ($locator::class !== DefaultFileLocator::class) {
+                throw new InvalidArgumentException(sprintf(
+                    'Discovered file locator for driver of type "%s" is an instance of "%s". This factory '
+                    . 'supports only the DefaultFileLocator when an extension is set for the file locator',
+                    $driver::class,
+                    $locator::class
+                ));
+            }
 
-		// Extra post-create options for DriverChain.
-		if ($driver instanceof MappingDriverChain && $config['drivers']) {
-			foreach ($config['drivers'] as $namespace => $driverConfig) {
-				$driverConfig = ArrayUtils::merge($this->getDefaultConfig(), $driverConfig);
-				$driver->addDriver($this->createDriver($driverConfig, $container), $namespace);
-			}
-		}
+            $driver->setLocator(new DefaultFileLocator($locator->getPaths(), $config['extension']));
+        }
 
-		return $driver;
-	}
+        // Extra post-create options for DriverChain.
+        if ($driver instanceof MappingDriverChain && $config['drivers']) {
+            foreach ($config['drivers'] as $namespace => $driverConfig) {
+                $driverConfig = ArrayUtils::merge($this->getDefaultConfig(), $driverConfig);
+                $driver->addDriver($this->createDriver($driverConfig, $container), $namespace);
+            }
+        }
 
-	/**
-	 * @inheritDoc
-	 */
-	protected function getDefaultConfig(): array {
-		return [
-			'class'     => MappingDriverChain::class,
-			'paths'     => [],
-			'cache'     => 'array',
-			'extension' => null,
-			'drivers'   => [],
-		];
-	}
+        return $driver;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultConfig(): array
+    {
+        return [
+            'class'     => MappingDriverChain::class,
+            'paths'     => [],
+            'cache'     => 'array',
+            'extension' => null,
+            'drivers'   => [],
+        ];
+    }
 }

--- a/src/Service/EntityManagerFactory.php
+++ b/src/Service/EntityManagerFactory.php
@@ -1,36 +1,38 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Skar\LaminasDoctrineORM\Service;
 
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\ORMException;
 use Psr\Container\ContainerInterface;
 
-class EntityManagerFactory extends AbstractFactory {
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @return EntityManager
-	 *
-	 * @throws ORMException
-	 */
-	public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): EntityManager {
-		return new EntityManager(
-			$container->get($this->getServiceName('connection')),
-			$container->get($this->getServiceName('configuration')),
-			$container->get($this->getServiceName('event_manager'))
-		);
-	}
+class EntityManagerFactory extends AbstractFactory
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        string $requestedName,
+        ?array $options = null
+    ): EntityManager {
+        return new EntityManager(
+            $container->get($this->getServiceName('connection')),
+            $container->get($this->getServiceName('configuration')),
+            $container->get($this->getServiceName('event_manager'))
+        );
+    }
 
-	/**
-	 * @inheritDoc
-	 */
-	protected function getDefaultConfig(): array {
-		return [
-			'connection'    => 'orm_default',
-			'configuration' => 'orm_default',
-			'event_manager' => 'orm_default',
-		];
-	}
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultConfig(): array
+    {
+        return [
+            'connection'    => 'orm_default',
+            'configuration' => 'orm_default',
+            'event_manager' => 'orm_default',
+        ];
+    }
 }

--- a/src/Service/EventManagerFactory.php
+++ b/src/Service/EventManagerFactory.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Skar\LaminasDoctrineORM\Service;
 
-use Interop\Container\ContainerInterface;
 use Doctrine\Common\EventManager;
 use InvalidArgumentException;
+use Psr\Container\ContainerInterface;
 
 class EventManagerFactory extends AbstractFactory {
 	/**

--- a/src/Service/EventManagerFactory.php
+++ b/src/Service/EventManagerFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Skar\LaminasDoctrineORM\Service;
@@ -7,39 +8,42 @@ use Doctrine\Common\EventManager;
 use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 
-class EventManagerFactory extends AbstractFactory {
-	/**
-	 * @inheritDoc
-	 *
-	 * @return EventManager
-	 */
-	public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): EventManager {
-		$eventManager = new EventManager();
+use function sprintf;
 
-		foreach ($this->config['subscribers'] as $subscriber) {
-			if (!$container->has($subscriber)) {
-				throw new InvalidArgumentException(sprintf('Subscriber "%s" not found', $subscriber));
-			}
-			$eventManager->addEventSubscriber($container->get($subscriber));
-		}
+class EventManagerFactory extends AbstractFactory
+{
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(ContainerInterface $container, string $requestedName, ?array $options = null): EventManager
+    {
+        $eventManager = new EventManager();
 
-		foreach ($this->config['listeners'] as $listener) {
-			if (!$container->has($listener['listener'])) {
-				throw new InvalidArgumentException(sprintf('Listeners "%s" not found', $listener));
-			}
-			$eventManager->addEventListener($listener['events'], $container->get($listener['listener']));
-		}
+        foreach ($this->config['subscribers'] as $subscriber) {
+            if (! $container->has($subscriber)) {
+                throw new InvalidArgumentException(sprintf('Subscriber "%s" not found', $subscriber));
+            }
+            $eventManager->addEventSubscriber($container->get($subscriber));
+        }
 
-		return $eventManager;
-	}
+        foreach ($this->config['listeners'] as $listener) {
+            if (! $container->has($listener['listener'])) {
+                throw new InvalidArgumentException(sprintf('Listeners "%s" not found', $listener));
+            }
+            $eventManager->addEventListener($listener['events'], $container->get($listener['listener']));
+        }
 
-	/**
-	 * @inheritDoc
-	 */
-	protected function getDefaultConfig(): array {
-		return [
-			'subscribers' => [],
-			'listeners'   => [],
-		];
-	}
+        return $eventManager;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getDefaultConfig(): array
+    {
+        return [
+            'subscribers' => [],
+            'listeners'   => [],
+        ];
+    }
 }

--- a/src/Service/ServiceAbstractFactory.php
+++ b/src/Service/ServiceAbstractFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Skar\LaminasDoctrineORM\Service;
@@ -8,57 +9,68 @@ use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
 use Psr\Container\ContainerInterface;
 
-class ServiceAbstractFactory implements AbstractFactoryInterface {
-	/**
-	 * @inheritDoc
-	 */
-	public function canCreate(ContainerInterface $container, $requestedName) {
-		return str_starts_with($requestedName, 'doctrine.');
-	}
+use function array_key_exists;
+use function explode;
+use function is_callable;
+use function is_subclass_of;
+use function sprintf;
+use function str_starts_with;
+use function vsprintf;
 
-	/**
-	 * @inheritDoc
-	 */
-	public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null) {
-		$config = $container->get('config');
-		$factories = $config['doctrine_factories'];
-		$servicePath = explode('.', $requestedName);
+class ServiceAbstractFactory implements AbstractFactoryInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function canCreate(ContainerInterface $container, string $requestedName): bool
+    {
+        return str_starts_with($requestedName, 'doctrine.');
+    }
 
-		if (empty($servicePath[1]) || !array_key_exists($servicePath[1], $factories)) {
-			throw new ServiceNotFoundException(
-				sprintf('Factory for service "%s" could not be found', $servicePath[1])
-			);
-		}
-		$serviceName = $servicePath[1];
-		$serviceKey = 'orm_default';
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(ContainerInterface $container, string $requestedName, ?array $options = null): mixed
+    {
+        $config      = $container->get('config');
+        $factories   = $config['doctrine_factories'];
+        $servicePath = explode('.', $requestedName);
 
-		if (!empty($servicePath[2])) {
-			$serviceKey = $servicePath[2];
-		}
+        if (empty($servicePath[1]) || ! array_key_exists($servicePath[1], $factories)) {
+            throw new ServiceNotFoundException(
+                sprintf('Factory for service "%s" could not be found', $servicePath[1])
+            );
+        }
+        $serviceName = $servicePath[1];
+        $serviceKey  = 'orm_default';
 
-		$serviceConfig = [];
-		if (array_key_exists($serviceName, $config['doctrine'])) {
-			$serviceConfig = $config['doctrine'][$serviceName];
-		}
-		if (array_key_exists($serviceKey, $serviceConfig)) {
-			$serviceConfig = $serviceConfig[$serviceKey];
-		}
+        if (! empty($servicePath[2])) {
+            $serviceKey = $servicePath[2];
+        }
 
-		if (!is_subclass_of($factories[$serviceName], AbstractFactory::class)) {
-			throw new ServiceNotCreatedException(vsprintf('"%s" must be inherit from "%s"', [
-				$factories[$serviceName],
-				AbstractFactory::class,
-			]));
-		}
+        $serviceConfig = [];
+        if (array_key_exists($serviceName, $config['doctrine'])) {
+            $serviceConfig = $config['doctrine'][$serviceName];
+        }
+        if (array_key_exists($serviceKey, $serviceConfig)) {
+            $serviceConfig = $serviceConfig[$serviceKey];
+        }
 
-		$factory = new $factories[$serviceName]($serviceConfig);
+        if (! is_subclass_of($factories[$serviceName], AbstractFactory::class)) {
+            throw new ServiceNotCreatedException(vsprintf('"%s" must be inherit from "%s"', [
+                $factories[$serviceName],
+                AbstractFactory::class,
+            ]));
+        }
 
-		if (!is_callable($factory)) {
-			throw new ServiceNotCreatedException(vsprintf('"%s" must be callable', [
-				$factories[$serviceName],
-			]));
-		}
+        $factory = new $factories[$serviceName]($serviceConfig);
 
-		return $factory($container, $requestedName, $options);
-	}
+        if (! is_callable($factory)) {
+            throw new ServiceNotCreatedException(vsprintf('"%s" must be callable', [
+                $factories[$serviceName],
+            ]));
+        }
+
+        return $factory($container, $requestedName, $options);
+    }
 }

--- a/src/Service/ServiceAbstractFactory.php
+++ b/src/Service/ServiceAbstractFactory.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Skar\LaminasDoctrineORM\Service;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
+use Psr\Container\ContainerInterface;
 
 class ServiceAbstractFactory implements AbstractFactoryInterface {
 	/**


### PR DESCRIPTION
This PR makes the following changes:

- Changes the project's code style to be based on [the laminas-codingstandard](https://docs.laminas.dev/laminas-coding-standard/). This makes the code consistent with the styling applied in other laminas projects
- Cleans up the codebase after running PHP Code Sniffer on it
- Finishes the work of deprecating `Interop\Container\ContainerInterface` in favour of `Psr\Container\ContainerInterface` 

I'm not sure if it would have been better to have submitted two PRs, one with the first two changes and another with the second. But, as I made the changes, one seemed fair.